### PR TITLE
Do not install PSP if apiVersion not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not install PodSecurityPolicy if api not available.
+
 ## [0.0.1] - 2021-05-21
 
 [Unreleased]: https://github.com/giantswarm/flamethrower-app/compare/v0.0.1...HEAD

--- a/helm/flamethrower/templates/psp.yaml
+++ b/helm/flamethrower/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -29,3 +30,4 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}


### PR DESCRIPTION
This PR changes the helm templates to not install PodSecurityPolicies if their apiVersion is not available.

Towards giantswarm/giantswarm#23400