### PR TITLE
enable psp with global value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enable PSP installation with global value.
 - Do not install PodSecurityPolicy if api not available.
 
 ## [0.0.1] - 2021-05-21

--- a/helm/flamethrower/templates/psp.yaml
+++ b/helm/flamethrower/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+{{- if and (.Capabilities.APIVersions.Has "policy/v1beta1") (not .Values.global.podSecurityStandards.enforced) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/helm/flamethrower/values.schema.json
+++ b/helm/flamethrower/values.schema.json
@@ -1,0 +1,133 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "Installation": {
+            "type": "object",
+            "properties": {
+                "V1": {
+                    "type": "object",
+                    "properties": {
+                        "Registry": {
+                            "type": "object",
+                            "properties": {
+                                "Domain": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "flame": {
+            "type": "object",
+            "properties": {
+                "qps": {
+                    "type": "integer"
+                },
+                "target": {
+                    "type": "string"
+                }
+            }
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "pod": {
+            "type": "object",
+            "properties": {
+                "group": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceType": {
+            "type": "string"
+        }
+    }
+}

--- a/helm/flamethrower/values.yaml
+++ b/helm/flamethrower/values.yaml
@@ -36,3 +36,8 @@ flame:
   target: coredns
   # The target Queries Per Second (per replica)
   qps: 10000
+
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Enables PSP with global value.


Towards https://github.com/giantswarm/giantswarm/issues/23400

### Testing

Description on how flamethrower can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for flamethrower installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
